### PR TITLE
Added keyboard mode property to BPFormViewController

### DIFF
--- a/BPForms/BPFormViewController.h
+++ b/BPForms/BPFormViewController.h
@@ -22,6 +22,12 @@
 //  SOFTWARE.
 
 
+typedef NS_ENUM(NSInteger, BPFormKeyboardMode) {
+	BPFormKeyboardModeAuto		= -1,
+	BPFormKeyboardModeDontMove	= 0,
+    BPFormKeyboardModeMove		= 1
+};
+
 /**
  *  Main class, represents the form controller
  */
@@ -46,6 +52,13 @@
  *  Set this to use a custom height for footers
  */
 @property (nonatomic, assign) CGFloat customSectionFooterHeight;
+
+/**
+ *  Set this to manually specify if the form should try to adjust it's size for the keyboard.
+ *	
+ *	By default the form will check if it is in a popover, and let the popover adjust it's size instead of the form view itself.
+ */
+@property (nonatomic) BPFormKeyboardMode keyboardMode;
 
 /**
  *  Set the header title for a specified section


### PR DESCRIPTION
I was experiencing a lot of crashing trying to use BPFormViewController in a popover on iPad. It would try to move the form view, but the popover would also try to adjust, and Autolayout freaked out.

This change performs a check for a popover superview by default, if one is found the view does not try to resize in response to the keyboard. I also expose the `keyboardMode` property so you have the choice to forcibly respond to the keyboard, or not.
