### PR TITLE
Fixing issue where `customCellHeight` was not being applied to Input Text View Cells

### DIFF
--- a/BPForms/Cells/Input/BPFormInputTextViewCell.m
+++ b/BPForms/Cells/Input/BPFormInputTextViewCell.m
@@ -79,4 +79,12 @@
     }];
 }
 
+- (void)setCustomCellHeight:(CGFloat)customCellHeight {
+    [super setCustomCellHeight:customCellHeight];
+    CGFloat newCellHeight = self.customCellHeight;
+    [self.textView mas_updateConstraints:^(MASConstraintMaker *make) {
+        make.height.equalTo(@(newCellHeight));
+    }];
+}
+
 @end


### PR DESCRIPTION
The containing cell was resizing properly, but the text view itself was not.
