### PR TITLE
Fix Bottom Inset After Keyboard Disappears if there is a Toolbar

### DIFF
--- a/BPForms/BPFormViewController.m
+++ b/BPForms/BPFormViewController.m
@@ -150,11 +150,17 @@
 		[UIView animateWithDuration:0.25 animations:^{
             // get the existing inset and reset the bottom to 0
             UIEdgeInsets insets = self.tableView.contentInset;
-            insets.bottom = 0;
+            insets.bottom = [self bottomInsetWhenKeyboardIsHidden];
 			self.tableView.contentInset = insets;
 			self.tableView.scrollIndicatorInsets = insets;
 		}];
 	}
+}
+
+- (CGFloat)bottomInsetWhenKeyboardIsHidden {
+
+	BOOL isToolBarShowing = self.navigationController.toolbar && !self.navigationController.toolbar.hidden;
+	return isToolBarShowing ? self.navigationController.toolbar.frame.size.height : 0;
 }
 
 - (void)setupTableView {


### PR DESCRIPTION
If the view has a toolbar, the bottom inset of the tableview needs to take account for this. Interestingly when initially showing, this seems to be adapted automatically, but when setting the bottom inset to 0 after the keyboard disappears, this automatic inset gets lost.
